### PR TITLE
Use newer Bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,4 +32,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.2
+   2.4.4


### PR DESCRIPTION
Prevents noise from warnings, e.g.:

```
/Users/andy/.asdf/installs/ruby/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-1.17.2/lib/bundler/shared_helpers.rb:29: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
```