### PR TITLE
new(usr): Add first pass at Readwise API V3 (support for Reader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/readwise.svg)](https://badge.fury.io/rb/readwise) [![Ruby](https://github.com/joshbeckman/readwise-ruby/actions/workflows/ruby.yml/badge.svg)](https://github.com/joshbeckman/readwise-ruby/actions/workflows/ruby.yml)
 
-[Readwise](https://readwise.io/) is an application suite to store, revisit, and learn from your book and article highlights. This is a basic library to call the [Readwise API](https://readwise.io/api_deets) to read and write highlights.
+[Readwise](https://readwise.io/) is an application suite to store, revisit, and learn from your book and article highlights. This is a basic library to call the [Readwise API](https://readwise.io/api_deets) to read and write highlights, and manage Reader documents through the [Reader API](https://readwise.io/reader_api).
 
 This library is not at 100% coverage of the API, so if you need a method that is missing, open an issue or contribute changes!
 
@@ -25,6 +25,10 @@ Or install it yourself as:
 ## Usage
 
 First, obtain an API access token from https://readwise.io/access_token.
+
+### Highlights API (V2)
+
+The [V2 API](https://readwise.io/api_deets) provides access to your highlights and books:
 
 ```ruby
 client = Readwise::Client.new(token: token)
@@ -54,6 +58,80 @@ updated_tag = client.update_highlight_tag(highlight: highlight, tag: added_tag)
 
 # remove a tag from a highlight
 client.remove_highlight_tag(highlight: highlight, tag: added_tag)
+```
+
+### Reader API (V3)
+
+The [V3 API](https://readwise.io/reader_api) provides access to Readwise Reader functionality for managing documents (articles, PDFs, etc.):
+
+```ruby
+# Get all documents
+documents = client.get_documents
+
+# Get documents with filters
+documents = client.get_documents(
+  updated_after: '2023-01-01T00:00:00Z',
+  location: 'new',        # 'new', 'later', 'archive', or 'feed'
+  category: 'article'     # 'article', 'email', 'rss', 'highlight', 'note', 'pdf', 'epub', 'tweet', 'video'
+)
+
+# Get a specific document
+document = client.get_document(document_id: '123456')
+
+puts document.title
+puts document.author
+puts document.url
+puts document.reading_progress
+puts document.location
+puts document.category
+
+# Check document properties
+puts document.read?                    # reading progress >= 85%
+puts document.read?(threshold: 0.5)    # custom threshold
+puts document.parent?                  # is this a top-level document?
+puts document.child?                   # is this a highlight/note of another document?
+
+# Check location
+puts document.in_new?
+puts document.in_later?  
+puts document.in_archive?
+
+# Check category
+puts document.article?
+puts document.pdf?
+puts document.epub?
+puts document.tweet?
+puts document.video?
+puts document.book?
+puts document.email?
+puts document.rss?
+puts document.highlight?
+puts document.note?
+
+# Access timestamps
+puts document.created_at_time
+puts document.updated_at_time
+puts document.published_date_time
+
+# Create a new document
+document_create = Readwise::DocumentCreate.new(
+  url: 'https://example.com/article',
+  title: 'My Article',
+  author: 'John Doe',
+  html: '<p>Article content</p>',
+  summary: 'A brief summary',
+  location: 'new',           # 'new', 'later', 'archive', or 'feed'
+  category: 'article',       # 'article', 'email', 'rss', etc.
+  tags: ['technology', 'programming'],
+  notes: 'My personal notes',
+  should_clean_html: true,
+  saved_using: 'api'
+)
+
+document = client.create_document(document: document_create)
+
+# Create multiple documents
+documents = client.create_documents(documents: [document_create1, document_create2])
 ```
 
 ## Development

--- a/lib/readwise.rb
+++ b/lib/readwise.rb
@@ -1,5 +1,5 @@
-require 'readwise/version'
-require 'readwise/client'
+require_relative 'readwise/version'
+require_relative 'readwise/client'
 
 module Readwise
   class Error < StandardError; end

--- a/lib/readwise/client.rb
+++ b/lib/readwise/client.rb
@@ -243,7 +243,7 @@ module Readwise
         source: res['source'],
         source_url: res['source_url'],
         summary: res['summary'],
-        tags: res['tags'].map { |tag| transform_tag(tag) },
+        tags: (res['tags'] || []).map { |tag| transform_tag(tag) },
         title: res['title'],
         updated_at: res['updated_at'],
         url: res['url'],

--- a/lib/readwise/client.rb
+++ b/lib/readwise/client.rb
@@ -243,15 +243,25 @@ module Readwise
         source: res['source'],
         source_url: res['source_url'],
         summary: res['summary'],
-        tags: (res['tags'] || []).map { |tag| transform_tag(tag) },
+        tags: transform_tags(res['tags']),
         title: res['title'],
         updated_at: res['updated_at'],
         url: res['url'],
         word_count: res['word_count'],
       )
-    rescue TypeError
-      puts res
-      raise
+    end
+
+    def transform_tags(res)
+      if res.is_a?(Array)
+        res.map { |tag| transform_tag(tag) }
+      elsif res.is_a?(Hash)
+        res.map do |tag_id, tag|
+          tag['id'] = tag_id
+          transform_tag(tag)
+        end
+      else
+        []
+      end
     end
 
     def transform_tag(res)
@@ -260,7 +270,7 @@ module Readwise
       end
 
       Tag.new(
-        tag_id: res['id'].to_s,
+        tag_id: res['id']&.to_s,
         name: res['name'],
       )
     end

--- a/lib/readwise/client.rb
+++ b/lib/readwise/client.rb
@@ -283,7 +283,7 @@ module Readwise
         http.request(req)
       end
 
-      raise Error, 'Get request failed' unless res.is_a?(Net::HTTPSuccess)
+      raise Error, "Get request failed with status code: #{res.code}" unless res.is_a?(Net::HTTPSuccess)
 
       JSON.parse(res.body)
     end

--- a/lib/readwise/client.rb
+++ b/lib/readwise/client.rb
@@ -3,17 +3,56 @@ require 'net/http'
 require_relative 'book'
 require_relative 'highlight'
 require_relative 'tag'
+require_relative 'document'
 
 module Readwise
   class Client
     class Error < StandardError; end
 
     BASE_URL = "https://readwise.io/api/v2/"
+    V3_BASE_URL = "https://readwise.io/api/v3/"
 
     def initialize(token: nil)
       raise ArgumentError unless token
 
       @token = token.to_s
+    end
+
+    def create_document(document:)
+      raise ArgumentError unless document.is_a?(Readwise::DocumentCreate)
+
+      url = V3_BASE_URL + 'save/'
+
+      res = post_readwise_request(url, payload: document.serialize)
+      get_document(document_id: res['id'])
+    end
+
+    def create_documents(documents: [])
+      return [] unless documents.any?
+
+      documents.map do |document|
+        create_document(document: document)
+      end
+    end
+
+    def get_document(document_id:)
+      url = V3_BASE_URL + "list?id=#{document_id}"
+
+      res = get_readwise_request(url)
+
+      res['results'].map { |item| transform_document(item) }.first
+    end
+
+    def get_documents(updated_after: nil, location: nil, category: nil)
+      resp = documents_page(updated_after: updated_after, location: location, category: category)
+      next_page_cursor = resp[:next_page_cursor]
+      results = resp[:results]
+      while next_page_cursor
+        resp = documents_page(updated_after: updated_after, location: location, category: category, page_cursor: next_page_cursor)
+        results.concat(resp[:results])
+        next_page_cursor = resp[:next_page_cursor]
+      end
+      results.sort_by(&:created_at)
     end
 
     def create_highlight(highlight:)
@@ -101,6 +140,28 @@ module Readwise
 
     private
 
+    def documents_page(page_cursor: nil, updated_after:, location:, category:)
+      parsed_body = get_documents_page(page_cursor: page_cursor, updated_after: updated_after, location: location, category: category)
+      results = parsed_body.dig('results').map do |item|
+        transform_document(item)
+      end
+      {
+        results: results,
+        next_page_cursor: parsed_body.dig('nextPageCursor')
+      }
+    end
+
+    def get_documents_page(page_cursor: nil, updated_after:, location:, category:)
+      params = {}
+      params['updatedAfter'] = updated_after if updated_after
+      params['location'] = location if location
+      params['category'] = category if category
+      params['pageCursor'] = page_cursor if page_cursor
+      url = V3_BASE_URL + 'list/?' + URI.encode_www_form(params)
+
+      get_readwise_request(url)
+    end
+
     def export_page(page_cursor: nil, updated_after: nil, book_ids: [])
       parsed_body = get_export_page(page_cursor: page_cursor, updated_after: updated_after, book_ids: book_ids)
       results = parsed_body.dig('results').map do |item|
@@ -120,7 +181,6 @@ module Readwise
       url = BASE_URL + 'export/?' + URI.encode_www_form(params)
 
       get_readwise_request(url)
-
     end
 
     def transform_book(res)
@@ -163,6 +223,31 @@ module Readwise
         text: res['text'],
         updated_at: res['updated_at'],
         url: res['url'],
+      )
+    end
+
+    def transform_document(res)
+      Document.new(
+        author: res['author'],
+        category: res['category'],
+        created_at: res['created_at'],
+        html: res['html'],
+        id: res['id'].to_s,
+        image_url: res['image_url'],
+        location: res['location'],
+        notes: res['notes'],
+        parent_id: res['parent_id'],
+        published_date: res['published_date'],
+        reading_progress: res['reading_progress'],
+        site_name: res['site_name'],
+        source: res['source'],
+        source_url: res['source_url'],
+        summary: res['summary'],
+        tags: res['tags'].map { |tag| transform_tag(tag) },
+        title: res['title'],
+        updated_at: res['updated_at'],
+        url: res['url'],
+        word_count: res['word_count'],
       )
     end
 

--- a/lib/readwise/client.rb
+++ b/lib/readwise/client.rb
@@ -252,6 +252,10 @@ module Readwise
     end
 
     def transform_tag(res)
+      if res.is_a?(String)
+        return Tag.new(name: res)
+      end
+
       Tag.new(
         tag_id: res['id'].to_s,
         name: res['name'],

--- a/lib/readwise/client.rb
+++ b/lib/readwise/client.rb
@@ -249,6 +249,9 @@ module Readwise
         url: res['url'],
         word_count: res['word_count'],
       )
+    rescue TypeError
+      puts res
+      raise
     end
 
     def transform_tag(res)

--- a/lib/readwise/document.rb
+++ b/lib/readwise/document.rb
@@ -1,0 +1,140 @@
+require 'time'
+
+module Readwise
+  Document = Struct.new(
+    'ReadwiseDocument',
+    :author,
+    :category,  # One of: article, email, rss, highlight, note, pdf, epub, tweet or video.
+                # Default is guessed based on the URL, usually article.
+    :created_at,
+    :html,
+    :id,
+    :image_url,
+    :location,  # One of: new, later, archive or feed. Default is new.
+    :notes,
+    :published_date,
+    :reading_progress,
+    :site_name,
+    :source,
+    :source_url,
+    :summary,
+    :tags,
+    :title,
+    :updated_at,
+    :url,
+    :word_count,
+    :parent_id, # both highlights and notes made in Reader are also considered Documents.
+                # Highlights and notes will have `parent_id` set, which is the Document id
+                # of the article/book/etc and highlight that they belong to, respectively.
+    keyword_init: true
+  ) do
+    def created_at_time
+      return unless created_at
+
+      Time.parse(created_at)
+    end
+
+    def updated_at_time
+      return unless updated_at
+
+      Time.parse(updated_at)
+    end
+
+    def published_date_time
+      return unless published_date
+
+      Time.at(published_date/1000)
+    end
+
+    def read?(threshold: 0.85)
+      reading_progress >= threshold
+    end
+
+    def parent?
+      parent_id.nil?
+    end
+
+    def child?
+      !parent?
+    end
+
+    def in_new?
+      location == 'new'
+    end
+
+    def in_later?
+      location == 'later'
+    end
+
+    def in_archive?
+      location == 'archive'
+    end
+
+    def pdf?
+      category == 'pdf'
+    end
+
+    def epub?
+      category == 'epub'
+    end
+
+    def tweet?
+      category == 'tweet'
+    end
+
+    def video?
+      category == 'video'
+    end
+
+    def article?
+      category == 'article'
+    end
+
+    def book?
+      category == 'book'
+    end
+
+    def email?
+      category == 'email'
+    end
+
+    def rss?
+      category == 'rss'
+    end
+
+    def highlight?
+      category == 'highlight'
+    end
+
+    def note?
+      category == 'note'
+    end
+
+    def serialize
+      to_h
+    end
+  end
+
+  DocumentCreate = Struct.new(
+    'ReadwiseDocumentCreate',
+    :author,
+    :category,  # One of: article, email, rss, highlight, note, pdf, epub, tweet or video.
+                # Default is guessed based on the URL, usually article.
+    :html,
+    :image_url,
+    :location,  # One of: new, later, archive or feed. Default is new.
+    :notes,
+    :published_date,
+    :saved_using,
+    :should_clean_html,
+    :summary,
+    :tags,
+    :title,
+    :url,
+    keyword_init: true
+  ) do
+    def serialize
+      to_h.compact
+    end
+  end
+end

--- a/spec/fixtures/document.json
+++ b/spec/fixtures/document.json
@@ -1,0 +1,25 @@
+{
+  "id": "123456",
+  "author": "John Doe",
+  "category": "article",
+  "created_at": "2023-01-15T10:30:00Z",
+  "html": "<p>This is some sample HTML content.</p>",
+  "image_url": "https://example.com/image.jpg",
+  "location": "new",
+  "notes": "Some notes about this document",
+  "parent_id": null,
+  "published_date": 1673780400000,
+  "reading_progress": 0.75,
+  "site_name": "Example Site",
+  "source": "web",
+  "source_url": "https://example.com/article",
+  "summary": "This is a summary of the article",
+  "tags": [
+    {"id": "tag1", "name": "technology"},
+    {"id": "tag2", "name": "programming"}
+  ],
+  "title": "Sample Article Title",
+  "updated_at": "2023-01-16T12:00:00Z",
+  "url": "https://example.com/article",
+  "word_count": 1200
+}

--- a/spec/fixtures/document_create.json
+++ b/spec/fixtures/document_create.json
@@ -1,0 +1,4 @@
+{
+  "id": "123456",
+  "url": "https://example.com/created-article"
+}

--- a/spec/fixtures/document_list.json
+++ b/spec/fixtures/document_list.json
@@ -1,0 +1,52 @@
+{
+  "results": [
+    {
+      "id": "123456",
+      "author": "John Doe",
+      "category": "article",
+      "created_at": "2023-01-15T10:30:00Z",
+      "html": "<p>This is some sample HTML content.</p>",
+      "image_url": "https://example.com/image.jpg",
+      "location": "new",
+      "notes": "Some notes about this document",
+      "parent_id": null,
+      "published_date": 1673780400000,
+      "reading_progress": 0.75,
+      "site_name": "Example Site",
+      "source": "web",
+      "source_url": "https://example.com/article",
+      "summary": "This is a summary of the article",
+      "tags": [
+        {"id": "tag1", "name": "technology"},
+        {"id": "tag2", "name": "programming"}
+      ],
+      "title": "Sample Article Title",
+      "updated_at": "2023-01-16T12:00:00Z",
+      "url": "https://example.com/article",
+      "word_count": 1200
+    },
+    {
+      "id": "789012",
+      "author": "Jane Smith",
+      "category": "pdf",
+      "created_at": "2023-01-14T08:15:00Z",
+      "html": null,
+      "image_url": null,
+      "location": "later",
+      "notes": null,
+      "parent_id": "123456",
+      "published_date": null,
+      "reading_progress": 0.1,
+      "site_name": null,
+      "source": "upload",
+      "source_url": null,
+      "summary": null,
+      "tags": {},
+      "title": "PDF Document",
+      "updated_at": "2023-01-14T08:15:00Z",
+      "url": null,
+      "word_count": 5000
+    }
+  ],
+  "nextPageCursor": null
+}

--- a/spec/fixtures/document_tags_string.json
+++ b/spec/fixtures/document_tags_string.json
@@ -1,0 +1,22 @@
+{
+  "id": "string-tags-doc",
+  "author": "Test Author",
+  "category": "article",
+  "created_at": "2023-01-15T10:30:00Z",
+  "html": "<p>Content with string tags</p>",
+  "image_url": null,
+  "location": "new",
+  "notes": null,
+  "parent_id": null,
+  "published_date": null,
+  "reading_progress": 0.5,
+  "site_name": "Test Site",
+  "source": "web",
+  "source_url": "https://example.com/string-tags",
+  "summary": "Document with string tags",
+  "tags": ["tag1", "tag2", "tag3"],
+  "title": "Document with String Tags",
+  "updated_at": "2023-01-15T10:30:00Z",
+  "url": "https://example.com/string-tags",
+  "word_count": 500
+}

--- a/spec/readwise/client_spec.rb
+++ b/spec/readwise/client_spec.rb
@@ -1,5 +1,6 @@
 require 'readwise/client'
 require 'readwise/highlight'
+require 'readwise/document'
 require "rspec/file_fixtures"
 
 RSpec.describe Readwise::Client do
@@ -97,6 +98,220 @@ RSpec.describe Readwise::Client do
 
       book = subject.get_book(book_id: "12345")
       expect(book).to be_instance_of Readwise::Book
+    end
+  end
+
+  context 'documents (V3 API)' do
+    context 'creating a document' do
+      let(:document_create_response) { fixture('document_create.json').from_json(false) }
+      let(:document_response) { { 'results' => [fixture('document.json').from_json(false)] } }
+
+      it 'can create a document' do
+        expect(subject).to receive(:post_readwise_request).and_return(document_create_response)
+        expect(subject).to receive(:get_readwise_request).and_return(document_response)
+
+        create_req = Readwise::DocumentCreate.new(
+          title: 'Test Document',
+          url: 'https://example.com/test'
+        )
+        document = subject.create_document(document: create_req)
+        expect(document).to be_instance_of Readwise::Document
+      end
+
+      it 'raises error when document is not DocumentCreate instance' do
+        expect { subject.create_document(document: 'invalid') }.to raise_error(ArgumentError)
+      end
+
+      it 'can create multiple documents' do
+        expect(subject).to receive(:post_readwise_request).twice.and_return(document_create_response)
+        expect(subject).to receive(:get_readwise_request).twice.and_return(document_response)
+
+        create_req1 = Readwise::DocumentCreate.new(title: 'Test 1', url: 'https://example.com/1')
+        create_req2 = Readwise::DocumentCreate.new(title: 'Test 2', url: 'https://example.com/2')
+
+        documents = subject.create_documents(documents: [create_req1, create_req2])
+        expect(documents).to be_an(Array)
+        expect(documents.size).to eq(2)
+        expect(documents.first).to be_instance_of Readwise::Document
+      end
+
+      it 'returns empty array when no documents provided' do
+        result = subject.create_documents(documents: [])
+        expect(result).to eq([])
+      end
+    end
+
+    context 'retrieving a document' do
+      let(:document_response) { { 'results' => [fixture('document.json').from_json(false)] } }
+
+      it 'can retrieve a single document' do
+        expect(subject).to receive(:get_readwise_request).and_return(document_response)
+
+        document = subject.get_document(document_id: '123456')
+        expect(document).to be_instance_of Readwise::Document
+        expect(document.id).to eq('123456')
+      end
+    end
+
+    context 'retrieving documents' do
+      let(:page1_response) { fixture('document_list.json').from_json(false) }
+      let(:page2_response) { { 'results' => [], 'nextPageCursor' => nil } }
+
+      it 'can retrieve all documents' do
+        expect(subject).to receive(:get_documents_page).and_return(page1_response)
+
+        documents = subject.get_documents
+        expect(documents).to be_an(Array)
+        expect(documents.size).to eq(2)
+        expect(documents.first).to be_instance_of Readwise::Document
+      end
+
+      it 'handles pagination correctly' do
+        page1_with_cursor = page1_response.merge('nextPageCursor' => 'cursor123')
+
+        expect(subject).to receive(:get_documents_page)
+          .with(updated_after: nil, location: nil, category: nil, page_cursor: nil)
+          .and_return(page1_with_cursor)
+
+        expect(subject).to receive(:get_documents_page)
+          .with(updated_after: nil, location: nil, category: nil, page_cursor: 'cursor123')
+          .and_return(page2_response)
+
+        documents = subject.get_documents
+        expect(documents).to be_an(Array)
+        expect(documents.size).to eq(2)
+      end
+
+      it 'sorts documents by created_at' do
+        expect(subject).to receive(:get_documents_page).and_return(page1_response)
+
+        documents = subject.get_documents
+        created_times = documents.map(&:created_at_time).compact
+        expect(created_times).to eq(created_times.sort)
+      end
+
+      it 'passes filter parameters' do
+        expect(subject).to receive(:get_documents_page)
+          .with(updated_after: '2023-01-01', location: 'new', category: 'article', page_cursor: nil)
+          .and_return(page1_response)
+
+        subject.get_documents(updated_after: '2023-01-01', location: 'new', category: 'article')
+      end
+    end
+
+    context 'transform methods' do
+      it 'transforms document with array tags' do
+        document_data = fixture('document.json').from_json(false)
+        result = subject.send(:transform_document, document_data)
+
+        expect(result).to be_instance_of Readwise::Document
+        expect(result.tags).to be_an(Array)
+        expect(result.tags.first).to be_instance_of Readwise::Tag
+      end
+
+      it 'transforms document with hash tags' do
+        document_data = fixture('document_list.json').from_json(false)['results'][1]
+        result = subject.send(:transform_document, document_data)
+
+        expect(result).to be_instance_of Readwise::Document
+        expect(result.tags).to be_an(Array)
+      end
+
+      it 'transforms document with string tags' do
+        document_data = fixture('document_tags_string.json').from_json(false)
+        result = subject.send(:transform_document, document_data)
+
+        expect(result).to be_instance_of Readwise::Document
+        expect(result.tags).to be_an(Array)
+        expect(result.tags.first).to be_instance_of Readwise::Tag
+        expect(result.tags.first.name).to eq('tag1')
+      end
+
+      it 'handles empty tags' do
+        document_data = fixture('document.json').from_json(false).merge('tags' => nil)
+        result = subject.send(:transform_document, document_data)
+
+        expect(result).to be_instance_of Readwise::Document
+        expect(result.tags).to eq([])
+      end
+    end
+
+    context 'transform_tags method' do
+      it 'transforms array of tag objects' do
+        tags_data = [
+          { 'id' => 'tag1', 'name' => 'technology' },
+          { 'id' => 'tag2', 'name' => 'programming' }
+        ]
+
+        result = subject.send(:transform_tags, tags_data)
+        expect(result).to be_an(Array)
+        expect(result.size).to eq(2)
+        expect(result.first).to be_instance_of Readwise::Tag
+        expect(result.first.name).to eq('technology')
+      end
+
+      it 'transforms hash of tags' do
+        tags_data = {
+          'tag1' => { 'name' => 'technology' },
+          'tag2' => { 'name' => 'programming' }
+        }
+
+        result = subject.send(:transform_tags, tags_data)
+        expect(result).to be_an(Array)
+        expect(result.size).to eq(2)
+        expect(result.first).to be_instance_of Readwise::Tag
+        expect(result.first.tag_id).to eq('tag1')
+      end
+
+      it 'transforms array of strings' do
+        tags_data = ['tag1', 'tag2', 'tag3']
+
+        result = subject.send(:transform_tags, tags_data)
+        expect(result).to be_an(Array)
+        expect(result.size).to eq(3)
+        expect(result.first).to be_instance_of Readwise::Tag
+        expect(result.first.name).to eq('tag1')
+      end
+
+      it 'returns empty array for invalid input' do
+        result = subject.send(:transform_tags, 'invalid')
+        expect(result).to eq([])
+      end
+
+      it 'returns empty array for nil input' do
+        result = subject.send(:transform_tags, nil)
+        expect(result).to eq([])
+      end
+    end
+  end
+
+  context 'error handling' do
+    it 'raises error with status code on failed GET request' do
+      allow(Net::HTTP).to receive(:start).and_return(double(code: '404', is_a?: false))
+
+      expect { subject.send(:get_readwise_request, 'https://example.com') }
+        .to raise_error(Readwise::Client::Error, 'Get request failed with status code: 404')
+    end
+
+    it 'raises error on failed POST request' do
+      allow(Net::HTTP).to receive(:start).and_return(double(is_a?: false))
+
+      expect { subject.send(:post_readwise_request, 'https://example.com', payload: {}) }
+        .to raise_error(Readwise::Client::Error, 'Post request failed')
+    end
+
+    it 'raises error on failed PATCH request' do
+      allow(Net::HTTP).to receive(:start).and_return(double(is_a?: false))
+
+      expect { subject.send(:patch_readwise_request, 'https://example.com', payload: {}) }
+        .to raise_error(Readwise::Client::Error, 'Patch request failed')
+    end
+
+    it 'raises error on failed DELETE request' do
+      allow(Net::HTTP).to receive(:start).and_return(double(is_a?: false))
+
+      expect { subject.send(:delete_readwise_request, 'https://example.com') }
+        .to raise_error(Readwise::Client::Error, 'Delete request failed')
     end
   end
 end

--- a/spec/readwise/document_spec.rb
+++ b/spec/readwise/document_spec.rb
@@ -1,0 +1,297 @@
+require 'readwise/document'
+require "rspec/file_fixtures"
+
+RSpec.describe Readwise::Document do
+  let(:document_data) do
+    {
+      id: '123456',
+      author: 'John Doe',
+      category: 'article',
+      created_at: '2023-01-15T10:30:00Z',
+      html: '<p>This is some sample HTML content.</p>',
+      image_url: 'https://example.com/image.jpg',
+      location: 'new',
+      notes: 'Some notes about this document',
+      parent_id: nil,
+      published_date: 1673780400000,
+      reading_progress: 0.75,
+      site_name: 'Example Site',
+      source: 'web',
+      source_url: 'https://example.com/article',
+      summary: 'This is a summary of the article',
+      tags: [],
+      title: 'Sample Article Title',
+      updated_at: '2023-01-16T12:00:00Z',
+      url: 'https://example.com/article',
+      word_count: 1200
+    }
+  end
+
+  subject { described_class.new(**document_data) }
+
+  describe '#created_at_time' do
+    it 'parses created_at timestamp' do
+      expect(subject.created_at_time).to eq(Time.parse('2023-01-15T10:30:00Z'))
+    end
+
+    it 'returns nil when created_at is nil' do
+      document = described_class.new(**document_data.merge(created_at: nil))
+      expect(document.created_at_time).to be_nil
+    end
+  end
+
+  describe '#updated_at_time' do
+    it 'parses updated_at timestamp' do
+      expect(subject.updated_at_time).to eq(Time.parse('2023-01-16T12:00:00Z'))
+    end
+
+    it 'returns nil when updated_at is nil' do
+      document = described_class.new(**document_data.merge(updated_at: nil))
+      expect(document.updated_at_time).to be_nil
+    end
+  end
+
+  describe '#published_date_time' do
+    it 'converts milliseconds timestamp to Time' do
+      expect(subject.published_date_time).to eq(Time.at(1673780400))
+    end
+
+    it 'returns nil when published_date is nil' do
+      document = described_class.new(**document_data.merge(published_date: nil))
+      expect(document.published_date_time).to be_nil
+    end
+  end
+
+  describe '#read?' do
+    it 'returns true when reading progress meets default threshold' do
+      expect(subject.read?).to be false
+      
+      document = described_class.new(**document_data.merge(reading_progress: 0.85))
+      expect(document.read?).to be true
+    end
+
+    it 'returns true when reading progress meets custom threshold' do
+      expect(subject.read?(threshold: 0.5)).to be true
+      expect(subject.read?(threshold: 0.8)).to be false
+    end
+  end
+
+  describe 'parent/child methods' do
+    describe '#parent?' do
+      it 'returns true when parent_id is nil' do
+        expect(subject.parent?).to be true
+      end
+
+      it 'returns false when parent_id is present' do
+        document = described_class.new(**document_data.merge(parent_id: '789'))
+        expect(document.parent?).to be false
+      end
+    end
+
+    describe '#child?' do
+      it 'returns false when parent_id is nil' do
+        expect(subject.child?).to be false
+      end
+
+      it 'returns true when parent_id is present' do
+        document = described_class.new(**document_data.merge(parent_id: '789'))
+        expect(document.child?).to be true
+      end
+    end
+  end
+
+  describe 'location methods' do
+    describe '#in_new?' do
+      it 'returns true when location is new' do
+        expect(subject.in_new?).to be true
+      end
+
+      it 'returns false when location is not new' do
+        document = described_class.new(**document_data.merge(location: 'later'))
+        expect(document.in_new?).to be false
+      end
+    end
+
+    describe '#in_later?' do
+      it 'returns false when location is new' do
+        expect(subject.in_later?).to be false
+      end
+
+      it 'returns true when location is later' do
+        document = described_class.new(**document_data.merge(location: 'later'))
+        expect(document.in_later?).to be true
+      end
+    end
+
+    describe '#in_archive?' do
+      it 'returns false when location is new' do
+        expect(subject.in_archive?).to be false
+      end
+
+      it 'returns true when location is archive' do
+        document = described_class.new(**document_data.merge(location: 'archive'))
+        expect(document.in_archive?).to be true
+      end
+    end
+  end
+
+  describe 'category methods' do
+    describe '#article?' do
+      it 'returns true when category is article' do
+        expect(subject.article?).to be true
+      end
+
+      it 'returns false when category is not article' do
+        document = described_class.new(**document_data.merge(category: 'pdf'))
+        expect(document.article?).to be false
+      end
+    end
+
+    describe '#pdf?' do
+      it 'returns false when category is article' do
+        expect(subject.pdf?).to be false
+      end
+
+      it 'returns true when category is pdf' do
+        document = described_class.new(**document_data.merge(category: 'pdf'))
+        expect(document.pdf?).to be true
+      end
+    end
+
+    describe '#epub?' do
+      it 'returns false when category is article' do
+        expect(subject.epub?).to be false
+      end
+
+      it 'returns true when category is epub' do
+        document = described_class.new(**document_data.merge(category: 'epub'))
+        expect(document.epub?).to be true
+      end
+    end
+
+    describe '#tweet?' do
+      it 'returns false when category is article' do
+        expect(subject.tweet?).to be false
+      end
+
+      it 'returns true when category is tweet' do
+        document = described_class.new(**document_data.merge(category: 'tweet'))
+        expect(document.tweet?).to be true
+      end
+    end
+
+    describe '#video?' do
+      it 'returns false when category is article' do
+        expect(subject.video?).to be false
+      end
+
+      it 'returns true when category is video' do
+        document = described_class.new(**document_data.merge(category: 'video'))
+        expect(document.video?).to be true
+      end
+    end
+
+    describe '#book?' do
+      it 'returns false when category is article' do
+        expect(subject.book?).to be false
+      end
+
+      it 'returns true when category is book' do
+        document = described_class.new(**document_data.merge(category: 'book'))
+        expect(document.book?).to be true
+      end
+    end
+
+    describe '#email?' do
+      it 'returns false when category is article' do
+        expect(subject.email?).to be false
+      end
+
+      it 'returns true when category is email' do
+        document = described_class.new(**document_data.merge(category: 'email'))
+        expect(document.email?).to be true
+      end
+    end
+
+    describe '#rss?' do
+      it 'returns false when category is article' do
+        expect(subject.rss?).to be false
+      end
+
+      it 'returns true when category is rss' do
+        document = described_class.new(**document_data.merge(category: 'rss'))
+        expect(document.rss?).to be true
+      end
+    end
+
+    describe '#highlight?' do
+      it 'returns false when category is article' do
+        expect(subject.highlight?).to be false
+      end
+
+      it 'returns true when category is highlight' do
+        document = described_class.new(**document_data.merge(category: 'highlight'))
+        expect(document.highlight?).to be true
+      end
+    end
+
+    describe '#note?' do
+      it 'returns false when category is article' do
+        expect(subject.note?).to be false
+      end
+
+      it 'returns true when category is note' do
+        document = described_class.new(**document_data.merge(category: 'note'))
+        expect(document.note?).to be true
+      end
+    end
+  end
+
+  describe '#serialize' do
+    it 'returns a hash representation' do
+      result = subject.serialize
+      expect(result).to be_a(Hash)
+      expect(result[:id]).to eq('123456')
+      expect(result[:title]).to eq('Sample Article Title')
+    end
+  end
+end
+
+RSpec.describe Readwise::DocumentCreate do
+  let(:create_data) do
+    {
+      author: 'Test Author',
+      category: 'article',
+      html: '<p>Test content</p>',
+      image_url: 'https://example.com/image.jpg',
+      location: 'new',
+      notes: 'Test notes',
+      published_date: 1673780400000,
+      saved_using: 'api',
+      should_clean_html: true,
+      summary: 'Test summary',
+      tags: ['tag1', 'tag2'],
+      title: 'Test Title',
+      url: 'https://example.com/test'
+    }
+  end
+
+  subject { described_class.new(**create_data) }
+
+  describe '#serialize' do
+    it 'returns compacted hash without nil values' do
+      result = subject.serialize
+      expect(result).to be_a(Hash)
+      expect(result.keys).not_to include(nil)
+      expect(result[:title]).to eq('Test Title')
+      expect(result[:url]).to eq('https://example.com/test')
+    end
+
+    it 'excludes nil values from serialization' do
+      document = described_class.new(title: 'Test', url: 'https://example.com', notes: nil)
+      result = document.serialize
+      expect(result).not_to have_key(:notes)
+      expect(result[:title]).to eq('Test')
+    end
+  end
+end

--- a/spec/readwise_spec.rb
+++ b/spec/readwise_spec.rb
@@ -1,3 +1,5 @@
+require 'readwise'
+
 RSpec.describe Readwise do
   it "has a version number" do
     expect(Readwise::VERSION).not_to be nil


### PR DESCRIPTION
Note that this is clearly still in beta (liable to change) because there are cases where the docs don't match the data (e.g. `published_date`).

Addresses https://github.com/joshbeckman/readwise-ruby/issues/1