### PR TITLE
Update development dependencies to solve error

### DIFF
--- a/readwise.gemspec
+++ b/readwise.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.2"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.6"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-file_fixtures", "~> 0.1.6"
 end


### PR DESCRIPTION
:wave: I was seeing the following error when trying to run the specs locally.
```
readwise-ruby main % be rake
rake aborted!
NoMethodError: undefined method `=~' for an instance of Proc
/Users/andy/.local/share/mise/installs/ruby/3.3.7/bin/bundle:25:in `load'
/Users/andy/.local/share/mise/installs/ruby/3.3.7/bin/bundle:25:in `<main>'
(See full trace by running task with --trace)
```
I'm not fully sure where it's coming from (`--trace` didn't help) but updating the development dependencies resolved it.