### PR TITLE
chore(deps): Update bundler and rake for ruby 3.2+

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-06-29
+- Handle absent tags in transforming highlights
+
 ## [1.0.0] - 2025-06-29
 - Add Readwise API v3 support for Reader documents ([#13](https://github.com/joshbeckman/readwise-ruby/pull/13))
 - Add `daily_review` client method and Review type ([#14](https://github.com/joshbeckman/readwise-ruby/pull/14))

--- a/lib/readwise/client.rb
+++ b/lib/readwise/client.rb
@@ -227,7 +227,7 @@ module Readwise
         location_type: res['location_type'],
         note: res['note'],
         readwise_url: res['readwise_url'],
-        tags: res['tags'].map { |tag| transform_tag(tag) },
+        tags: (res['tags'] || []).map { |tag| transform_tag(tag) },
         text: res['text'],
         updated_at: res['updated_at'],
         url: res['url'],

--- a/lib/readwise/version.rb
+++ b/lib/readwise/version.rb
@@ -1,3 +1,3 @@
 module Readwise
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/readwise.gemspec
+++ b/readwise.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.2"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.4"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-file_fixtures", "~> 0.1.6"
 end


### PR DESCRIPTION
Ruby <=3.1 is end-of-life so we can stop supporting it.

Reimplementation of [Update development dependencies to solve error by andyw8 · Pull Request https://github.com/joshbeckman/readwise-ruby/pull/15 · joshbeckman/readwise-ruby](https://github.com/joshbeckman/readwise-ruby/pull/15)